### PR TITLE
Install docker-compose (and docker from dependencies) via pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 junos-eznc
 pynetbox
 jxmlease
+docker-compose


### PR DESCRIPTION
Would it be possible to install `docker-compose` from `pip` requirements?

It is needed when playing with Ansible `built-in` modules as `docker` and `docker-compose`. 

My use case was to spin a headless chrome container to take a screenshot from a website within an Ansible playbook so I can append it to a report. I believe it might be useful!

Hope it helps!
