### PR TITLE
Update Alpine Linux to 3.16.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #
 # ********************************************************
 
-FROM amd64/alpine:3.16.2
+FROM amd64/alpine:3.16.3
 
 # ==> Specify Python requirements filename;   default = "requirements.txt"
 # ==> Specify Ansible requirements filename;  default = "requirements.yml"
@@ -27,7 +27,7 @@ RUN apk add --no-cache sudo \
     gcc libxml2-dev libxslt-dev musl-dev \
     bash python3-dev openssh expect sshpass \
     libffi-dev openssl-dev build-base curl vim \
-    ansible-core=2.13.0-r0 \
+    ansible-core=2.13.6-r0 \
     ansible=5.8.0-r0
 
 # copy requirements.txt for Python and install


### PR DESCRIPTION
Includes update to ansible-core 2.13.6-r0. Tested against EBGP-WAN example files in JCL.