### PR TITLE
Build and publish a multi-architecture Ansible image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,41 +1,202 @@
-name: Docker Image CI
+name: Container Image
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["**"]
+    tags: ["*"]
   pull_request:
-    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_NAME: ghcr.io/juniper/nita-ansible
+  TEST_IMAGE: local/nita-ansible:test
 
 jobs:
+  validate:
+    name: Validate ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            architecture: amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            architecture: arm64
+            runner: ubuntu-24.04-arm
 
-  build:
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6.0.2
 
-    runs-on: ubuntu-latest
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.2.0
 
+      - name: Build validation image
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
+          load: true
+          tags: ${{ env.TEST_IMAGE }}
+          labels: org.opencontainers.image.source=https://github.com/Juniper/nita-ansible
+          cache-from: type=gha,scope=validate-${{ matrix.architecture }}
+          cache-to: type=gha,mode=max,scope=validate-${{ matrix.architecture }}
+
+      - name: Smoke-test Ansible runtime
+        run: |
+          docker run --rm "${TEST_IMAGE}" ansible --version
+          docker run --rm "${TEST_IMAGE}" python3 -c \
+            'import jnpr.junos, jxmlease, pynetbox, yaml'
+          docker run --rm "${TEST_IMAGE}" \
+            ansible-galaxy collection list juniper.device
+          docker run --rm "${TEST_IMAGE}" \
+            ansible-galaxy collection list junipernetworks.junos
+          docker run --rm "${TEST_IMAGE}" \
+            ansible-galaxy collection list netbox.netbox
+
+      - name: Scan HIGH and CRITICAL vulnerabilities
+        uses: aquasecurity/trivy-action@0.36.0
+        with:
+          image-ref: ${{ env.TEST_IMAGE }}
+          format: json
+          output: trivy-${{ matrix.architecture }}.json
+          severity: HIGH,CRITICAL
+          exit-code: "0"
+
+      - name: Upload vulnerability report
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: trivy-nita-ansible-${{ matrix.architecture }}
+          path: trivy-${{ matrix.architecture }}.json
+          if-no-files-found: warn
+          retention-days: 14
+
+  publish-platform:
+    name: Publish ${{ matrix.platform }} digest
+    needs: validate
+    if: >-
+      github.event_name == 'push' &&
+      github.repository == 'Juniper/nita-ansible' &&
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            architecture: amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            architecture: arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push platform digest
+        id: build
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: org.opencontainers.image.source=https://github.com/Juniper/nita-ansible
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          sbom: true
+          provenance: mode=max
+          cache-from: type=gha,scope=publish-${{ matrix.architecture }}
+          cache-to: type=gha,mode=max,scope=publish-${{ matrix.architecture }}
+
+      - name: Export digest marker
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          digest='${{ steps.build.outputs.digest }}'
+          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
+
+      - name: Upload digest marker
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: digest-${{ matrix.architecture }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-manifest:
+    name: Publish multi-platform manifest
+    needs: publish-platform
+    if: >-
+      github.event_name == 'push' &&
+      github.repository == 'Juniper/nita-ansible' &&
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
 
     steps:
-    - uses: actions/checkout@v6.0.2
+      - name: Download digest markers
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: digest-*
+          path: ${{ runner.temp }}/digests
+          merge-multiple: true
 
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag juniper/nita-ansible:$(cat VERSION.txt)
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.2.0
 
-    - name: Log in to GitHub Container Registry
-      if: github.event_name == 'push'
-      uses: docker/login-action@v4
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Push to GitHub Container Registry
-      if: github.event_name == 'push'
-      run: |
-        VERSION=$(cat VERSION.txt)
-        IMAGE=ghcr.io/${{ github.repository }}
-        docker tag juniper/nita-ansible:${VERSION} ${IMAGE,,}:${VERSION}
-        docker tag juniper/nita-ansible:${VERSION} ${IMAGE,,}:latest
-        docker push ${IMAGE,,}:${VERSION}
-        docker push ${IMAGE,,}:latest
+      - name: Assemble and inspect manifest
+        shell: bash
+        run: |
+          mapfile -t digest_files < <(find "${RUNNER_TEMP}/digests" -maxdepth 1 -type f | sort)
+          test "${#digest_files[@]}" -eq 2
+
+          sources=()
+          for digest_file in "${digest_files[@]}"; do
+            sources+=("${IMAGE_NAME}@sha256:$(basename "${digest_file}")")
+          done
+
+          short_sha="${GITHUB_SHA:0:12}"
+          tags=("${IMAGE_NAME}:sha-${short_sha}")
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            primary_tag=latest
+            tags+=("${IMAGE_NAME}:latest")
+          else
+            primary_tag="${GITHUB_REF#refs/tags/}"
+            tags+=("${IMAGE_NAME}:${primary_tag}")
+          fi
+
+          tag_args=()
+          for tag in "${tags[@]}"; do
+            tag_args+=(--tag "${tag}")
+          done
+
+          docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
+          docker buildx imagetools inspect "${IMAGE_NAME}:${primary_tag}"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -128,6 +128,39 @@ jobs:
           cache-from: type=gha,scope=publish-${{ matrix.architecture }}
           cache-to: type=gha,mode=max,scope=publish-${{ matrix.architecture }}
 
+      - name: Smoke-test published platform digest
+        env:
+          PUBLISHED_IMAGE: ${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+        run: |
+          docker pull "${PUBLISHED_IMAGE}"
+          docker run --rm "${PUBLISHED_IMAGE}" ansible --version
+          docker run --rm "${PUBLISHED_IMAGE}" python3 -c \
+            'import jnpr.junos, jxmlease, pynetbox, yaml'
+          docker run --rm "${PUBLISHED_IMAGE}" \
+            ansible-galaxy collection list juniper.device
+          docker run --rm "${PUBLISHED_IMAGE}" \
+            ansible-galaxy collection list junipernetworks.junos
+          docker run --rm "${PUBLISHED_IMAGE}" \
+            ansible-galaxy collection list netbox.netbox
+
+      - name: Scan published platform digest
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: json
+          output: trivy-published-${{ matrix.architecture }}.json
+          severity: HIGH,CRITICAL
+          exit-code: "0"
+
+      - name: Upload published-digest vulnerability report
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: trivy-published-nita-ansible-${{ matrix.architecture }}
+          path: trivy-published-${{ matrix.architecture }}.json
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Export digest marker
         run: |
           mkdir -p "${RUNNER_TEMP}/digests"
@@ -190,6 +223,12 @@ jobs:
             tags+=("${IMAGE_NAME}:latest")
           else
             primary_tag="${GITHUB_REF#refs/tags/}"
+            if ((${#primary_tag} > 128)) ||
+              [[ ! "${primary_tag}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]*$ ]]; then
+              echo "::error::Git tag '${primary_tag}' cannot be published unchanged as a Docker tag."
+              echo "::error::Use 1-128 ASCII letters, digits, underscores, periods, or dashes."
+              exit 1
+            fi
             tags+=("${IMAGE_NAME}:${primary_tag}")
           fi
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -61,7 +61,7 @@ jobs:
             ansible-galaxy collection list netbox.netbox
 
       - name: Scan HIGH and CRITICAL vulnerabilities
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.TEST_IMAGE }}
           format: json


### PR DESCRIPTION
## Summary

- build and smoke-test `linux/amd64` on `ubuntu-24.04` and `linux/arm64` on
  `ubuntu-24.04-arm` for every branch push and pull request
- validate Ansible plus the packaged Junos/NetBox network dependencies and
  collections
- publish per-platform digests only from trusted upstream `main` or Git-tag
  pushes, then assemble one multi-platform manifest
- smoke-test and scan the exact pushed platform digest before manifest assembly
- publish `latest`, `sha-<short-commit>`, or the exact Git tag as appropriate
- attach an OCI source label, BuildKit SBOM/provenance, and downloadable
  non-blocking Trivy HIGH/CRITICAL reports
- retain `VERSION.txt` for local metadata without reading, changing, or
  committing it in CI

`nita-ansible-ee` is intentionally unchanged because it is not used by the NITA
installer or Kubernetes runtime.

## Validation

- native ARM image build and runtime smoke test passed locally
- [fork workflow](https://github.com/tbelz/nita-ansible/actions/runs/29828253961)
  validates both native architectures without authenticating or creating a
  personal GHCR package
- workflow passes `actionlint` and YAML validation

Related to Juniper/nita#51.

References Juniper/nita#29 without closing it; full release automation remains
separate.
